### PR TITLE
fix typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ __pycache__
 .idea
 .DS_Store
 trips.db
-test_database.db
+test_trips.db


### PR DESCRIPTION
.gitignore wasn't properly ignoring the test database file due to a typo. @KelseyStiff @Sargazi77 